### PR TITLE
Improve error message upon failing test

### DIFF
--- a/src/graderPublic/java/h08/TutorTests_H5_2.java
+++ b/src/graderPublic/java/h08/TutorTests_H5_2.java
@@ -33,8 +33,7 @@ public class TutorTests_H5_2 {
                 assertionThrown = true;
                 assertEquals("Expected h08.MockException to be thrown, but nothing was thrown.",
                     targetException.getMessage(),
-                    "Die Methode \"testException\" wirft zwar einen AssertionError, verwendet jedoch die Methode " +
-                        "assertThrowsExactly nicht korrekt.");
+                    "Die Methode \"testException\" wirft zwar einen AssertionError, die Nachricht des AssertionErrors entspricht jedoch nicht der erwarteten Nachricht.");
             }
         }
 


### PR DESCRIPTION
I feel like the current message can be a bit confusing due to it simply stating an expected String without stating where this String is expected to appear. This would change the message in the result file to further explain why the test failed.